### PR TITLE
Remove _total from network metrics

### DIFF
--- a/config/infrastructure.json
+++ b/config/infrastructure.json
@@ -727,7 +727,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_rx_bytes_total",
+              "expr": "network_rx_bytes",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -819,7 +819,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_tx_bytes_total",
+              "expr": "network_tx_bytes",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -911,7 +911,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_rx_packets_total",
+              "expr": "network_rx_packets",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -1003,7 +1003,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_tx_packets_total",
+              "expr": "network_tx_packets",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -1095,7 +1095,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_rx_errors_total",
+              "expr": "network_rx_errors",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -1187,7 +1187,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_tx_drops_total",
+              "expr": "network_tx_drops",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -1279,7 +1279,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_rx_drops_total",
+              "expr": "network_rx_drops",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"
@@ -1371,7 +1371,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "network_tx_errors_total",
+              "expr": "network_tx_errors",
               "legendFormat": "{{interface}}",
               "range": true,
               "refId": "A"

--- a/internal/pollster/network/network.go
+++ b/internal/pollster/network/network.go
@@ -66,18 +66,14 @@ func readNetworkStats() ([]networkStats, error) {
 }
 
 func RegisterNetworkMetrics(mc *collector.MetriclyCollector) {
-	mc.AddMetric("network_rx_bytes_total", "total bytes received", []string{"hostname", "interface"})
-	mc.AddMetric("network_tx_bytes_total", "total bytes transmitted", []string{"hostname", "interface"})
-	mc.AddMetric("network_rx_packets_total", "total packets received", []string{"hostname", "interface"})
-	mc.AddMetric("network_tx_packets_total", "total packets transmitted", []string{"hostname", "interface"})
-	mc.AddMetric("network_rx_bytes_total", "total bytes received", []string{"hostname", "interface"})
-	mc.AddMetric("network_tx_bytes_total", "total bytes transmitted", []string{"hostname", "interface"})
-	mc.AddMetric("network_rx_packets_total", "total packets received", []string{"hostname", "interface"})
-	mc.AddMetric("network_tx_packets_total", "total packets transmitted", []string{"hostname", "interface"})
-	mc.AddMetric("network_rx_errors_total", "total errors received", []string{"hostname", "interface"})
-	mc.AddMetric("network_tx_errors_total", "total errors transmitted", []string{"hostname", "interface"})
-	mc.AddMetric("network_rx_drops_total", "total drops received", []string{"hostname", "interface"})
-	mc.AddMetric("network_tx_drops_total", "total drops transmitted", []string{"hostname", "interface"})
+	mc.AddMetric("network_rx_bytes", "total bytes received", []string{"hostname", "interface"})
+	mc.AddMetric("network_tx_bytes", "total bytes transmitted", []string{"hostname", "interface"})
+	mc.AddMetric("network_rx_packets", "total packets received", []string{"hostname", "interface"})
+	mc.AddMetric("network_tx_packets", "total packets transmitted", []string{"hostname", "interface"})
+	mc.AddMetric("network_rx_errors", "total errors received", []string{"hostname", "interface"})
+	mc.AddMetric("network_tx_errors", "total errors transmitted", []string{"hostname", "interface"})
+	mc.AddMetric("network_rx_drops", "total drops received", []string{"hostname", "interface"})
+	mc.AddMetric("network_tx_drops", "total drops transmitted", []string{"hostname", "interface"})
 }
 
 func subtractCurrPrev(prev, curr networkStats) networkStats {
@@ -125,49 +121,49 @@ func ReportNetworkUsage(mc *collector.MetriclyCollector) {
 	for _, stat := range increaseNWStats {
 
 		mc.UpdateMetric(
-			"network_rx_bytes_total",
+			"network_rx_bytes",
 			float64(stat.bytesRx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_tx_bytes_total",
+			"network_tx_bytes",
 			float64(stat.bytesTx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_rx_packets_total",
+			"network_rx_packets",
 			float64(stat.packetsRx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_tx_packets_total",
+			"network_tx_packets",
 			float64(stat.packetsTx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_rx_errors_total",
+			"network_rx_errors",
 			float64(stat.errorsRx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_tx_errors_total",
+			"network_tx_errors",
 			float64(stat.errorsTx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_rx_drops_total",
+			"network_rx_drops",
 			float64(stat.dropsRx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)
 
 		mc.UpdateMetric(
-			"network_tx_drops_total",
+			"network_tx_drops",
 			float64(stat.dropsTx),
 			[]string{common.GetHostname(), stat.interfaceName},
 		)


### PR DESCRIPTION
Since network metrics are no longer counter, but gauge. It should no longer have _total as a suffix.