### PR TITLE
Use context to better handle routines after termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o metricly cmd/collector/main.go
 FROM quay.io/jitesoft/alpine:3.20.3
 WORKDIR /root
 COPY --from=builder /app/metricly .
+COPY ./config/healthcheck .
+RUN chmod +x /root/healthcheck
 RUN mkdir /etc/metricly
 # Expose the port
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ $ podman build -t metricly .
 $ podman run --rm -d -p 8080:8080 --name metricly \
 -v ./config/config.yaml:/etc/metricly/config.yaml:ro \
 -e HOSTNAME=${HOSTNAME} \
+--health-cmd "/root/healthcheck metricly" \
 localhost/metricly:latest
 ```
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -28,17 +28,14 @@ func main() {
 	cc := collector.CreateMetricCollector()
 	prometheus.MustRegister(cc)
 
-	// Context for clean shutdown
+	// Context for clean shutdown (parent ctx)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start metrics collection
+	// Start metrics collection before starting server
 	server.StartMetricsCollection(ctx, config.CollectionInterval, cc)
 
-	err = server.StartServer(config)
-
-	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to start server: %v", err))
-	}
+	// Start metricly metrics hosting server
+	server.StartMetriclyServer(ctx, config)
 
 }

--- a/config/healthcheck
+++ b/config/healthcheck
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ss -lnp | grep $1 || netstat -plnt | grep -i listen | grep $1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       - PROC_NETWORK_DEV=/host/root/proc/net/dev
       - PROC_DISK_MOUNTS=/host/root/proc/mounts
       - PROC_DISK_STATS=/host/root/proc/diskstats
+    healthcheck:
+      test: ["CMD", "/root/healthcheck metricly"]
+      interval: 30s   
+      timeout: 5s     
+      retries: 3      
+      start_period: 10s 
 
   prometheus:
     container_name: metricly_prometheus

--- a/internal/pollster/cpu/cpu.go
+++ b/internal/pollster/cpu/cpu.go
@@ -137,7 +137,7 @@ func RegisterCPUMetrics(mc *collector.MetriclyCollector) {
 
 // collectCPUUsage collects the CPU usage as a percentage over a defined time interval.
 func ReportCpuUsage(mc *collector.MetriclyCollector) {
-	slog.Info("Polling CPU metrics...")
+	start := time.Now()
 
 	// Capture initial CPU stats
 	prevCPU, _ := readCPUStats()
@@ -152,5 +152,5 @@ func ReportCpuUsage(mc *collector.MetriclyCollector) {
 	mc.UpdateMetric("cpu_system", calculateSystemUsage(prevCPU, currCPU), []string{})
 	mc.UpdateMetric("cpu_steal", calculateStealUsage(prevCPU, currCPU), []string{})
 
-	slog.Info("Polling CPU metrics complete")
+	slog.Info(fmt.Sprintf("Collected CPU metrics in %s", time.Since(start)))
 }

--- a/internal/pollster/disk/disk.go
+++ b/internal/pollster/disk/disk.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 )
 
 var (
@@ -181,7 +182,7 @@ func RegisterDiskMetrics(mc *collector.MetriclyCollector) {
 
 // ReportDiskMetrics reports disk metrics periodically.
 func ReportDiskUsage(mc *collector.MetriclyCollector) {
-	slog.Info("Polling Disk metrics...")
+	start := time.Now()
 	// get disk I/O usage
 	diskStatsMap, err := parseDiskStats()
 	if err != nil {
@@ -267,5 +268,5 @@ func ReportDiskUsage(mc *collector.MetriclyCollector) {
 			[]string{mount},
 		)
 	}
-	slog.Info("Polling CPU metrics complete")
+	slog.Info(fmt.Sprintf("Collected Disk metrics in %s", time.Since(start)))
 }

--- a/internal/pollster/memory/memory.go
+++ b/internal/pollster/memory/memory.go
@@ -8,6 +8,7 @@ import (
 	"metricly/pkg/common"
 	"os"
 	"strings"
+	"time"
 )
 
 var (
@@ -91,7 +92,7 @@ func RegisterMemoryMetrics(mc *collector.MetriclyCollector) {
 }
 
 func ReportMemoryUsage(mc *collector.MetriclyCollector) {
-	slog.Info("Polling Memory metrics...")
+	start := time.Now()
 	memStats, err := readMemoryStats()
 	if err != nil {
 		slog.Warn(fmt.Sprint(err))
@@ -139,5 +140,5 @@ func ReportMemoryUsage(mc *collector.MetriclyCollector) {
 		float64(memStats.HugePagesSurp),
 		[]string{},
 	)
-	slog.Info("Polling Memory metrics complete")
+	slog.Info(fmt.Sprintf("Collected Memory metrics in %s", time.Since(start)))
 }

--- a/internal/pollster/network/network.go
+++ b/internal/pollster/network/network.go
@@ -107,7 +107,7 @@ func calculatePerSecondMetrics(prev, curr []networkStats) ([]networkStats, error
 
 func ReportNetworkUsage(mc *collector.MetriclyCollector) {
 
-	slog.Info("Polling Network metrics...")
+	start := time.Now()
 	prevNWStat, _ := readNetworkStats()
 	time.Sleep(1 * time.Second)
 	currNWStat, _ := readNetworkStats()
@@ -168,5 +168,5 @@ func ReportNetworkUsage(mc *collector.MetriclyCollector) {
 			[]string{stat.interfaceName},
 		)
 	}
-	slog.Info("Polling Network metrics complete")
+	slog.Info(fmt.Sprintf("Collected Network metrics in %s", time.Since(start)))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,15 +1,21 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	v1 "metricly/api/v1"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"metricly/config"
 )
 
-func StartServer(conf *config.Config) error {
+func StartMetriclyServer(ctx context.Context, conf *config.Config) {
 
 	mux := http.NewServeMux()
 	v1.HandleRoutes(mux, conf)
@@ -20,6 +26,31 @@ func StartServer(conf *config.Config) error {
 		Addr:    metricsURL,
 		Handler: mux,
 	}
-	slog.Info("Start hosting metrics...")
-	return server.ListenAndServe()
+	slog.Info(fmt.Sprintf("Starting to host metrics on %s ...", metricsURL))
+
+	errChan := make(chan error)
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errChan <- err
+		}
+	}()
+
+	slog.Info("Started Metricly...")
+
+	select {
+	case err := <-errChan:
+		slog.Error(fmt.Sprintf("failed to listen and serve: %v", err))
+	case <-signalChan:
+		slog.Error("Received shutdown signal...")
+
+		// derived ctx from
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Second))
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			slog.Error(fmt.Sprintf("failed to shutdown gracefully: %v", err))
+		}
+	}
 }


### PR DESCRIPTION
- Add healthcheck for metricly container
- Report duration in which metrics were collected