### PR TITLE
Ignore all pseudo filesystems in disk collector

### DIFF
--- a/config/infrastructure.json
+++ b/config/infrastructure.json
@@ -1938,7 +1938,7 @@
                   }
                 ]
               },
-              "unit": "decgbytes"
+              "unit": "percent"
             },
             "overrides": []
           },
@@ -1965,7 +1965,7 @@
           "targets": [
             {
               "editorMode": "code",
-              "expr": "metricly_disk_used_bytes{hostname=\"$host\"}/1024/1024/1024",
+              "expr": "(100*metricly_disk_used_bytes{hostname=\"$host\"})/metricly_disk_total_bytes{hostname=\"$host\"}",
               "legendFormat": "{{mount_point}}",
               "range": true,
               "refId": "A"

--- a/internal/pollster/disk/disk_test.go
+++ b/internal/pollster/disk/disk_test.go
@@ -21,7 +21,11 @@ sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
 	if err != nil {
 		t.Fatalf("failed to setup collector file: %v", err)
 	}
-	defer os.Remove(collectorSource)
+	tmpSrc := procMounts
+	defer func() {
+		os.Remove(collectorSource)
+		procMounts = tmpSrc
+	}()
 	procMounts = collectorSource
 
 	// start testing target function
@@ -29,11 +33,11 @@ sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(mounts) != 5 {
+	if len(mounts) != 2 {
 		t.Errorf("incorrect count of mounts: %v", mounts)
 	}
 
-	expectedMounts := []string{"/", "/dev", "/dev/pts", "/sys", "/boot"}
+	expectedMounts := []string{"/", "/boot"}
 	for i := range len(mounts) {
 		if mounts[i] != expectedMounts[i] {
 			t.Error("incorrect mount")
@@ -52,7 +56,11 @@ func TestParseDiskStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to setup collector file: %v", err)
 	}
-	defer os.Remove(collectorSource)
+	tmpSrc := procDiskStats
+	defer func() {
+		os.Remove(collectorSource)
+		procDiskStats = tmpSrc
+	}()
 	procDiskStats = collectorSource
 
 	// start testing target function


### PR DESCRIPTION
When running inside container, prepend the path where host filesystem is mounted.

Also, disk usage per mount reports usage in term of percent rather than bytes. Give much better understanding of the storage available.